### PR TITLE
Show resource count when there are no control failures

### DIFF
--- a/src/compliance/Compliance.tsx
+++ b/src/compliance/Compliance.tsx
@@ -401,7 +401,7 @@ function makeResultsLabel(workloadScanData: WorkloadConfigurationScanSummary[], 
       </HeadlampLink>
     );
   } else {
-    return failCount;
+    return passedCount;
   }
 }
 


### PR DESCRIPTION
Fixes #23

Simply show the passedCount in the resources column when there are no failures, so the resources column is not 0 for everything.