### PR TITLE
Have the ID Column link to the Control screen

### DIFF
--- a/src/compliance/Compliance.tsx
+++ b/src/compliance/Compliance.tsx
@@ -281,12 +281,16 @@ function ConfigurationScanningListView(
             header: 'ID',
             accessorKey: 'controlID',
             Cell: ({ cell }: any) => (
-              <Link
-                target="_blank"
-                href={'https://hub.armosec.io/docs/' + cell.getValue().toLowerCase()}
+              <HeadlampLink
+                routeName={RoutingName.KubescapeControlResults}
+                params={{
+                  control: cell.getValue(),
+                }}
               >
-                <div>{cell.getValue()}</div>
-              </Link>
+                <div>
+                  {cell.getValue()}
+                </div>
+              </HeadlampLink>
             ),
             gridTemplate: 'auto',
           },


### PR DESCRIPTION
Fixes #24

I wasn't sure if you'd rather have an `accessorFn` instead, but this works.