### PR TITLE
Use component label instead of instance for kubescape namespace detection

### DIFF
--- a/src/custom-objects/api-queries.ts
+++ b/src/custom-objects/api-queries.ts
@@ -41,7 +41,7 @@ export async function getKubescapeNamespace() {
   const queryParams = new URLSearchParams();
   queryParams.append(
     'labelSelector',
-    'app.kubernetes.io/name=kubescape-operator,app.kubernetes.io/instance=kubescape'
+    'app.kubernetes.io/name=kubescape-operator,app.kubernetes.io/component=kubescape'
   );
   const response = await request(`api/v1/pods?${queryParams.toString()}`);
   namespace = response.items[0]?.metadata?.namespace;


### PR DESCRIPTION
Fixes #22

Justification:

In https://github.com/kubescape/helm-charts/blob/main/charts/kubescape-operator/templates/_helpers.tpl the labels are defined as such:

```
{{- define "kubescape-operator.selectorLabels" -}}
app.kubernetes.io/name: {{ include "kubescape-operator.name" . }}
app.kubernetes.io/instance: {{ .Release.Name }}
app.kubernetes.io/component: {{ .app }}
{{- end }}
```

The `instance` label is based on release name, which is defined by the user (and in my case it was `release-name`). Component is defined by the helm chart as the app name.