### PR TITLE
Upgrade @dagrejs/dagre to v2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "kubescape-plugin",
-  "version": "v0.10.4",
+  "version": "v0.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubescape-plugin",
-      "version": "v0.10.4",
+      "version": "v0.10.5",
       "dependencies": {
-        "@dagrejs/dagre": "^1.1.8",
+        "@dagrejs/dagre": "^2.0.4",
+        "@dagrejs/graphlib": "^2.2.4",
         "@xyflow/react": "^12.10.1"
       },
       "devDependencies": {
@@ -127,7 +128,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -535,7 +535,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -559,25 +558,27 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@dagrejs/dagre": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.8.tgz",
-      "integrity": "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==",
-      "license": "MIT",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
+      "integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
       "dependencies": {
-        "@dagrejs/graphlib": "2.2.4"
+        "@dagrejs/graphlib": "3.0.4"
       }
+    },
+    "node_modules/@dagrejs/dagre/node_modules/@dagrejs/graphlib": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
+      "integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg=="
     },
     "node_modules/@dagrejs/graphlib": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
       "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
-      "license": "MIT",
       "engines": {
         "node": ">17.0.0"
       }
@@ -646,7 +647,6 @@
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -693,7 +693,6 @@
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2041,7 +2040,6 @@
       "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -2111,7 +2109,6 @@
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -2220,7 +2217,6 @@
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -2308,7 +2304,6 @@
       "integrity": "sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
@@ -3514,7 +3509,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -3847,7 +3841,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4312,7 +4305,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4324,7 +4316,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4455,7 +4446,6 @@
       "integrity": "sha512-XxXP5tL1txl13YFtrECECQYeZjBZad4fyd3cFV4a19LkAY/bIp9fev3US4S5fDVV2JaYFiKAZ/GRTOLer+mbyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.48.0",
@@ -4486,7 +4476,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -5049,8 +5038,7 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -5104,7 +5092,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5151,7 +5138,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5991,7 +5977,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6883,8 +6868,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -6993,7 +6977,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7817,7 +7800,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7895,7 +7877,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7952,7 +7933,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8016,7 +7996,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8134,7 +8113,6 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8199,7 +8177,6 @@
       "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8233,7 +8210,6 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8312,7 +8288,6 @@
       "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -8323,7 +8298,6 @@
       "integrity": "sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
         "eslint": "^9.0.0 || ^8.0.0"
@@ -10025,7 +9999,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -11054,7 +11027,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -11096,7 +11068,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12339,8 +12310,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12356,7 +12326,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -13485,7 +13454,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13588,7 +13556,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -13888,7 +13855,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13931,7 +13897,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14037,7 +14002,6 @@
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14345,8 +14309,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -14765,7 +14728,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -14971,7 +14933,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15428,7 +15389,6 @@
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.17.tgz",
       "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -16571,7 +16531,6 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17032,7 +16991,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -17192,7 +17150,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17358,7 +17315,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17875,7 +17831,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@kinvolk/headlamp-plugin": "^0.13.0"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^1.1.8",
+    "@dagrejs/dagre": "^2.0.4",
+    "@dagrejs/graphlib": "^2.2.4",
     "@xyflow/react": "^12.10.1"
   }
 }

--- a/src/networkpolicies/Diagram.tsx
+++ b/src/networkpolicies/Diagram.tsx
@@ -3,17 +3,17 @@
 */
 import '@xyflow/react/dist/style.css';
 import './style.css';
-import dagre from '@dagrejs/dagre';
 import { SectionBox, Tabs as HeadlampTabs } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { KubeObject } from '@kinvolk/headlamp-plugin/lib/k8s/cluster';
 import Editor from '@monaco-editor/react';
 import { Box } from '@mui/material';
-import { Edge, MarkerType, Node, ReactFlow, ReactFlowInstance } from '@xyflow/react';
+import { ReactFlow, ReactFlowInstance } from '@xyflow/react';
 import * as yaml from 'js-yaml';
 import { useEffect, useState } from 'react';
 import { getURLSegments } from '../common/url';
 import { generatedNetworkPolicyClass } from '../model';
 import { GeneratedNetworkPolicy } from '../softwarecomposition/GeneratedNetworkPolicy';
+import { createNodes, layoutElements } from './layout';
 import { nodeTypes } from './nodes';
 
 export default function KubescapeNetworkPolicyDiagram() {
@@ -107,107 +107,4 @@ function NetworkPolicyDiagram(props: Readonly<{ generatedNetworkPolicy: Generate
       </Box>
     </SectionBox>
   );
-}
-
-function layoutElements(nodes: Node[], edges: Edge[]) {
-  const dagreGraph = new dagre.graphlib.Graph();
-  dagreGraph.setDefaultEdgeLabel(() => ({}));
-  dagreGraph.setGraph({ rankdir: 'LR' });
-
-  const nodeWidth = 360;
-  const nodeHeight = 70;
-
-  nodes.forEach(node => {
-    dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
-  });
-
-  edges.forEach(edge => {
-    dagreGraph.setEdge(edge.source, edge.target);
-  });
-
-  dagre.layout(dagreGraph);
-
-  nodes.forEach(node => {
-    const nodeWithPosition = dagreGraph.node(node.id);
-    node.position = {
-      x: nodeWithPosition.x,
-      y: nodeWithPosition.y,
-    };
-  });
-}
-
-function createNodes(networkPolicy: GeneratedNetworkPolicy): { nodes: Node[]; edges: Edge[] } {
-  const nodes: Node[] = [];
-  const edges: Edge[] = [];
-
-  const workloadNode: Node = {
-    id: 'main',
-    data: {
-      policy: networkPolicy,
-    },
-    position: { x: 0, y: 0 },
-    type: 'mainNode',
-  };
-  nodes.push(workloadNode);
-
-  if (networkPolicy.spec.spec.ingress) {
-    for (const ingress of networkPolicy.spec.spec.ingress) {
-      if (!ingress.from) {
-        continue;
-      }
-      for (const from of ingress.from) {
-        const node: Node = {
-          id: nodes.length.toString(),
-          data: {
-            peer: from,
-            policy: networkPolicy,
-            ports: ingress.ports,
-          },
-          position: { x: 0, y: 0 },
-          type: 'sourceNode',
-        };
-        nodes.push(node);
-
-        const edge: Edge = {
-          id: edges.length.toString(),
-          source: node.id,
-          target: workloadNode.id,
-          type: 'step',
-          markerEnd: { type: MarkerType.Arrow },
-        };
-        edges.push(edge);
-      }
-    }
-  }
-
-  if (networkPolicy.spec.spec.egress) {
-    for (const egress of networkPolicy.spec.spec.egress) {
-      if (!egress.to) {
-        continue;
-      }
-      for (const to of egress.to) {
-        const node: Node = {
-          id: nodes.length.toString(),
-          data: {
-            peer: to,
-            policy: networkPolicy,
-            ports: egress.ports,
-          },
-          position: { x: 0, y: 0 },
-          type: 'targetNode',
-        };
-        nodes.push(node);
-
-        const edge: Edge = {
-          id: edges.length.toString(),
-          source: workloadNode.id,
-          target: node.id,
-          type: 'step',
-          markerEnd: { type: MarkerType.Arrow },
-        };
-        edges.push(edge);
-      }
-    }
-  }
-  return { nodes, edges };
 }

--- a/src/networkpolicies/layout.test.ts
+++ b/src/networkpolicies/layout.test.ts
@@ -1,0 +1,180 @@
+import { Edge, MarkerType, Node } from '@xyflow/react';
+import { GeneratedNetworkPolicy } from '../softwarecomposition/GeneratedNetworkPolicy';
+import { createNodes, layoutElements } from './layout';
+
+function makePolicy(
+  overrides: Partial<Pick<GeneratedNetworkPolicy['spec']['spec'], 'ingress' | 'egress'>> = {}
+): GeneratedNetworkPolicy {
+  return {
+    metadata: {
+      creationTimestamp: '',
+      name: 'test-policy',
+      namespace: 'default',
+      cluster: '',
+      annotations: {},
+      labels: {},
+    },
+    spec: {
+      spec: {
+        podSelector: { matchLabels: { app: 'test' } },
+        ingress: overrides.ingress,
+        egress: overrides.egress,
+      },
+    },
+    policyRef: [],
+  };
+}
+
+describe('createNodes', () => {
+  it('creates a single main node when there are no ingress or egress rules', () => {
+    const policy = makePolicy();
+    const { nodes, edges } = createNodes(policy);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].id).toBe('main');
+    expect(nodes[0].type).toBe('mainNode');
+    expect(edges).toHaveLength(0);
+  });
+
+  it('creates source nodes and edges for ingress rules', () => {
+    const policy = makePolicy({
+      ingress: [
+        {
+          ports: [{ protocol: 'TCP', port: '80' }],
+          from: [
+            { podSelector: { matchLabels: { role: 'frontend' } } },
+            { namespaceSelector: { matchLabels: { env: 'prod' } } },
+          ],
+        },
+      ],
+    });
+    const { nodes, edges } = createNodes(policy);
+
+    expect(nodes).toHaveLength(3); // 1 main + 2 source
+    expect(nodes[1].type).toBe('sourceNode');
+    expect(nodes[2].type).toBe('sourceNode');
+
+    expect(edges).toHaveLength(2);
+    edges.forEach(edge => {
+      expect(edge.target).toBe('main');
+      expect(edge.markerEnd).toEqual({ type: MarkerType.Arrow });
+    });
+  });
+
+  it('creates target nodes and edges for egress rules', () => {
+    const policy = makePolicy({
+      egress: [
+        {
+          ports: [{ protocol: 'TCP', port: '443' }],
+          to: [{ ipBlock: { cidr: '10.0.0.0/8' } }],
+        },
+      ],
+    });
+    const { nodes, edges } = createNodes(policy);
+
+    expect(nodes).toHaveLength(2); // 1 main + 1 target
+    expect(nodes[1].type).toBe('targetNode');
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe('main');
+  });
+
+  it('handles both ingress and egress rules together', () => {
+    const policy = makePolicy({
+      ingress: [{ from: [{ podSelector: { matchLabels: { role: 'frontend' } } }] }],
+      egress: [{ to: [{ podSelector: { matchLabels: { role: 'db' } } }] }],
+    });
+    const { nodes, edges } = createNodes(policy);
+
+    expect(nodes).toHaveLength(3); // 1 main + 1 source + 1 target
+    expect(edges).toHaveLength(2);
+  });
+
+  it('skips ingress rules with no from field', () => {
+    const policy = makePolicy({
+      ingress: [{ ports: [{ protocol: 'TCP', port: '80' }] }],
+    });
+    const { nodes, edges } = createNodes(policy);
+
+    expect(nodes).toHaveLength(1); // only main
+    expect(edges).toHaveLength(0);
+  });
+
+  it('skips egress rules with no to field', () => {
+    const policy = makePolicy({
+      egress: [{ ports: [{ protocol: 'TCP', port: '443' }] }],
+    });
+    const { nodes, edges } = createNodes(policy);
+
+    expect(nodes).toHaveLength(1); // only main
+    expect(edges).toHaveLength(0);
+  });
+});
+
+describe('layoutElements', () => {
+  it('assigns positions to all nodes using dagre layout', () => {
+    const nodes: Node[] = [
+      { id: 'a', data: {}, position: { x: 0, y: 0 } },
+      { id: 'b', data: {}, position: { x: 0, y: 0 } },
+      { id: 'c', data: {}, position: { x: 0, y: 0 } },
+    ];
+    const edges: Edge[] = [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'b', target: 'c' },
+    ];
+
+    layoutElements(nodes, edges);
+
+    nodes.forEach(node => {
+      expect(typeof node.position.x).toBe('number');
+      expect(typeof node.position.y).toBe('number');
+      expect(Number.isFinite(node.position.x)).toBe(true);
+      expect(Number.isFinite(node.position.y)).toBe(true);
+    });
+  });
+
+  it('produces a left-to-right layout where connected nodes have increasing x', () => {
+    const nodes: Node[] = [
+      { id: 'a', data: {}, position: { x: 0, y: 0 } },
+      { id: 'b', data: {}, position: { x: 0, y: 0 } },
+    ];
+    const edges: Edge[] = [{ id: 'e1', source: 'a', target: 'b' }];
+
+    layoutElements(nodes, edges);
+
+    expect(nodes[0].position.x).toBeLessThan(nodes[1].position.x);
+  });
+
+  it('handles a single node with no edges', () => {
+    const nodes: Node[] = [{ id: 'a', data: {}, position: { x: 0, y: 0 } }];
+    const edges: Edge[] = [];
+
+    layoutElements(nodes, edges);
+
+    expect(Number.isFinite(nodes[0].position.x)).toBe(true);
+    expect(Number.isFinite(nodes[0].position.y)).toBe(true);
+  });
+
+  it('works end-to-end with createNodes output', () => {
+    const policy = makePolicy({
+      ingress: [{ from: [{ podSelector: { matchLabels: { role: 'frontend' } } }] }],
+      egress: [
+        {
+          to: [
+            { podSelector: { matchLabels: { role: 'db' } } },
+            { ipBlock: { cidr: '10.0.0.0/8' } },
+          ],
+        },
+      ],
+    });
+
+    const { nodes, edges } = createNodes(policy);
+    layoutElements(nodes, edges);
+
+    expect(nodes).toHaveLength(4); // 1 main + 1 source + 2 target
+    nodes.forEach(node => {
+      expect(Number.isFinite(node.position.x)).toBe(true);
+      expect(Number.isFinite(node.position.y)).toBe(true);
+    });
+  });
+});

--- a/src/networkpolicies/layout.ts
+++ b/src/networkpolicies/layout.ts
@@ -1,0 +1,110 @@
+import dagre from '@dagrejs/dagre';
+import { Graph } from '@dagrejs/graphlib';
+import { Edge, MarkerType, Node } from '@xyflow/react';
+import { GeneratedNetworkPolicy } from '../softwarecomposition/GeneratedNetworkPolicy';
+
+export function layoutElements(nodes: Node[], edges: Edge[]) {
+  const dagreGraph = new Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({ rankdir: 'LR' });
+
+  const nodeWidth = 360;
+  const nodeHeight = 70;
+
+  nodes.forEach(node => {
+    dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+  });
+
+  edges.forEach(edge => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  nodes.forEach(node => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    node.position = {
+      x: nodeWithPosition.x,
+      y: nodeWithPosition.y,
+    };
+  });
+}
+
+export function createNodes(networkPolicy: GeneratedNetworkPolicy): {
+  nodes: Node[];
+  edges: Edge[];
+} {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  const workloadNode: Node = {
+    id: 'main',
+    data: {
+      policy: networkPolicy,
+    },
+    position: { x: 0, y: 0 },
+    type: 'mainNode',
+  };
+  nodes.push(workloadNode);
+
+  if (networkPolicy.spec.spec.ingress) {
+    for (const ingress of networkPolicy.spec.spec.ingress) {
+      if (!ingress.from) {
+        continue;
+      }
+      for (const from of ingress.from) {
+        const node: Node = {
+          id: nodes.length.toString(),
+          data: {
+            peer: from,
+            policy: networkPolicy,
+            ports: ingress.ports,
+          },
+          position: { x: 0, y: 0 },
+          type: 'sourceNode',
+        };
+        nodes.push(node);
+
+        const edge: Edge = {
+          id: edges.length.toString(),
+          source: node.id,
+          target: workloadNode.id,
+          type: 'step',
+          markerEnd: { type: MarkerType.Arrow },
+        };
+        edges.push(edge);
+      }
+    }
+  }
+
+  if (networkPolicy.spec.spec.egress) {
+    for (const egress of networkPolicy.spec.spec.egress) {
+      if (!egress.to) {
+        continue;
+      }
+      for (const to of egress.to) {
+        const node: Node = {
+          id: nodes.length.toString(),
+          data: {
+            peer: to,
+            policy: networkPolicy,
+            ports: egress.ports,
+          },
+          position: { x: 0, y: 0 },
+          type: 'targetNode',
+        };
+        nodes.push(node);
+
+        const edge: Edge = {
+          id: edges.length.toString(),
+          source: workloadNode.id,
+          target: node.id,
+          type: 'step',
+          markerEnd: { type: MarkerType.Arrow },
+        };
+        edges.push(edge);
+      }
+    }
+  }
+  return { nodes, edges };
+}


### PR DESCRIPTION
## Summary
- Upgrades `@dagrejs/dagre` from `^1.1.8` to `2.0.4` and adds `@dagrejs/graphlib@2.2.4` as a separate dependency (breaking change in v2: graphlib was extracted into its own package)
- Extracts `layoutElements` and `createNodes` from `Diagram.tsx` into a standalone `layout.ts` module for testability
- Adds 10 unit tests covering node creation and dagre layout integration

## Test plan
- [x] `npm run tsc` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes (831 kB, same bundle size)
- [x] `npm run test` — 10 new tests pass
- [ ] Manual verification: open a Generated Network Policy diagram in Headlamp and confirm layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved diagram layout and node/edge construction into a dedicated, reusable layout module to simplify the diagram component.

* **Tests**
  * Added comprehensive tests covering node/edge generation and automated layout/positioning behavior.

* **Chores**
  * Updated project dependencies to newer compatible versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->