### PR TITLE
feat: add guided SecurityException form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2672,9 +2672,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2689,9 +2686,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2706,9 +2700,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,9 +2714,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2740,9 +2728,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2757,9 +2742,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2774,9 +2756,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2791,9 +2770,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2808,9 +2784,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2825,9 +2798,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2842,9 +2812,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2859,9 +2826,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2876,9 +2840,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3694,9 +3655,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3714,9 +3672,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [

--- a/src/compliance/WorkloadScanDetails.tsx
+++ b/src/compliance/WorkloadScanDetails.tsx
@@ -11,6 +11,7 @@ import { Link } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { StatusLabel, StatusLabelProps } from '../common/StatusLabel';
 import { getURLSegments } from '../common/url';
+import { CreateExceptionButton } from '../exceptions/CreateExceptionButton';
 import { RoutingName } from '../index';
 import { fetchObject, workloadConfigurationScanClass } from '../model';
 import { useRegoData } from '../rego';
@@ -102,13 +103,14 @@ function Controls(props: Readonly<{ workloadConfigurationScan: WorkloadConfigura
             id: 'Status',
             header: 'Status',
             accessorKey: 'status.status',
-            Cell: ({ row }: any) => makeStatusLabel(workloadConfigurationScan, row.original),
+            Cell: ({ row }: { row: { original: WorkloadConfigurationScan.Control } }) =>
+              makeStatusLabel(workloadConfigurationScan, row.original),
             gridTemplate: 'min-content',
           },
           {
             header: 'Control',
             accessorKey: 'controlID',
-            Cell: ({ cell }: any) => {
+            Cell: ({ cell }: { cell: { getValue: () => string } }) => {
               return (
                 <Link
                   target="_blank"
@@ -168,6 +170,32 @@ function Controls(props: Readonly<{ workloadConfigurationScan: WorkloadConfigura
                   </HeadlampLink>
                 );
               }
+            },
+            gridTemplate: 'min-content',
+          },
+          {
+            header: 'Exception',
+            accessorFn: (control: WorkloadConfigurationScan.Control) => {
+              const isFailed = control.status.status === 'failed';
+              const isExcepted =
+                workloadConfigurationScan.exceptedByPolicy || control.exceptedByPolicy;
+              if (!isFailed || isExcepted) {
+                return null;
+              }
+              return (
+                <CreateExceptionButton
+                  prefillControlID={control.controlID}
+                  prefillWorkloadKind={
+                    workloadConfigurationScan.metadata.labels['kubescape.io/workload-kind']
+                  }
+                  prefillWorkloadName={
+                    workloadConfigurationScan.metadata.labels['kubescape.io/workload-name']
+                  }
+                  prefillNamespace={
+                    workloadConfigurationScan.metadata.labels['kubescape.io/workload-namespace']
+                  }
+                />
+              );
             },
             gridTemplate: 'min-content',
           },

--- a/src/compliance/WorkloadScanDetails.tsx
+++ b/src/compliance/WorkloadScanDetails.tsx
@@ -194,6 +194,7 @@ function Controls(props: Readonly<{ workloadConfigurationScan: WorkloadConfigura
                   prefillNamespace={
                     workloadConfigurationScan.metadata.labels['kubescape.io/workload-namespace']
                   }
+                  defaultType="posture"
                 />
               );
             },

--- a/src/exceptions/CreateExceptionButton.tsx
+++ b/src/exceptions/CreateExceptionButton.tsx
@@ -1,0 +1,53 @@
+import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { useState } from 'react';
+import { SecurityExceptionForm } from './SecurityExceptionForm';
+
+interface CreateExceptionButtonProps {
+  prefillControlID?: string;
+  prefillCVEID?: string;
+  prefillWorkloadKind?: string;
+  prefillWorkloadName?: string;
+  prefillNamespace?: string;
+  buttonLabel?: string;
+  disabled?: boolean;
+}
+
+export function CreateExceptionButton(props: Readonly<CreateExceptionButtonProps>) {
+  const {
+    prefillControlID,
+    prefillCVEID,
+    prefillWorkloadKind,
+    prefillWorkloadName,
+    prefillNamespace,
+    buttonLabel,
+    disabled,
+  } = props;
+  const [open, setOpen] = useState<boolean>(false);
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        size="small"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        className="whitespace-nowrap"
+      >
+        {buttonLabel ?? 'Create Exception'}
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="md">
+        <DialogTitle>Create SecurityException</DialogTitle>
+        <DialogContent className="pt-4">
+          <SecurityExceptionForm
+            prefillControlID={prefillControlID}
+            prefillCVEID={prefillCVEID}
+            prefillWorkloadKind={prefillWorkloadKind}
+            prefillWorkloadName={prefillWorkloadName}
+            prefillNamespace={prefillNamespace}
+            onClose={() => setOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/exceptions/CreateExceptionButton.tsx
+++ b/src/exceptions/CreateExceptionButton.tsx
@@ -42,7 +42,7 @@ export function CreateExceptionButton(props: Readonly<CreateExceptionButtonProps
         </span>
       </Tooltip>
       <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="md">
-        <DialogTitle>Create SecurityException</DialogTitle>
+        <DialogTitle>Create Security Exception</DialogTitle>
         <DialogContent className="pt-4">
           <SecurityExceptionForm
             prefillControlID={prefillControlID}

--- a/src/exceptions/CreateExceptionButton.tsx
+++ b/src/exceptions/CreateExceptionButton.tsx
@@ -1,4 +1,5 @@
-import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { Button, Dialog, DialogContent, DialogTitle, IconButton, Tooltip } from '@mui/material';
+import { Icon } from '@iconify/react';
 import { useState } from 'react';
 import { SecurityExceptionForm } from './SecurityExceptionForm';
 
@@ -10,6 +11,8 @@ interface CreateExceptionButtonProps {
   prefillNamespace?: string;
   buttonLabel?: string;
   disabled?: boolean;
+  /** when provided, hide type chooser and preselect posture or vulnerability */
+  defaultType?: 'posture' | 'vulnerability';
 }
 
 export function CreateExceptionButton(props: Readonly<CreateExceptionButtonProps>) {
@@ -26,15 +29,18 @@ export function CreateExceptionButton(props: Readonly<CreateExceptionButtonProps
 
   return (
     <>
-      <Button
-        variant="contained"
-        size="small"
-        onClick={() => setOpen(true)}
-        disabled={disabled}
-        className="whitespace-nowrap"
-      >
-        {buttonLabel ?? 'Create Exception'}
-      </Button>
+      <Tooltip title={buttonLabel ?? 'Create Security Exception'}>
+        <span>
+          <IconButton
+            size="small"
+            onClick={() => setOpen(true)}
+            disabled={disabled}
+            aria-label={buttonLabel ?? 'Create Security Exception'}
+          >
+            <Icon icon="mdi:shield-plus-outline" />
+          </IconButton>
+        </span>
+      </Tooltip>
       <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="md">
         <DialogTitle>Create SecurityException</DialogTitle>
         <DialogContent className="pt-4">
@@ -44,6 +50,7 @@ export function CreateExceptionButton(props: Readonly<CreateExceptionButtonProps
             prefillWorkloadKind={prefillWorkloadKind}
             prefillWorkloadName={prefillWorkloadName}
             prefillNamespace={prefillNamespace}
+            defaultType={props.defaultType}
             onClose={() => setOpen(false)}
           />
         </DialogContent>

--- a/src/exceptions/SecurityExceptionForm.test.tsx
+++ b/src/exceptions/SecurityExceptionForm.test.tsx
@@ -1,0 +1,185 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { post } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
+import { SecurityExceptionForm } from './SecurityExceptionForm';
+
+jest.mock('@kinvolk/headlamp-plugin/lib/ApiProxy', () => ({
+  post: jest.fn(),
+}));
+
+jest.mock('@kinvolk/headlamp-plugin/lib/Utils', () => ({
+  getCluster: () => 'test-cluster',
+}));
+
+interface CreatedResource {
+  metadata: {
+    name: string;
+    namespace?: string;
+  };
+  kind: 'SecurityException' | 'ClusterSecurityException';
+}
+
+const postMock = post as jest.MockedFunction<typeof post>;
+
+function fillScope() {
+  fireEvent.change(screen.getByLabelText('Namespace'), { target: { value: 'default' } });
+  fireEvent.change(screen.getByLabelText('Workload kind'), { target: { value: 'Deployment' } });
+  fireEvent.change(screen.getByLabelText('Workload name'), { target: { value: 'nginx' } });
+}
+
+function selectOption(label: string, option: string) {
+  fireEvent.mouseDown(screen.getByLabelText(label));
+  fireEvent.click(screen.getByRole('option', { name: option }));
+}
+
+function enablePosture() {
+  fireEvent.click(screen.getByLabelText('Posture exception'));
+  fireEvent.change(screen.getByLabelText('Control ID'), { target: { value: 'C-0034' } });
+  selectOption('Action', 'alert_only');
+}
+
+function enableVulnerability() {
+  fireEvent.click(screen.getByLabelText('Vulnerability exception'));
+  fireEvent.change(screen.getByLabelText('CVE ID'), { target: { value: 'CVE-2021-44228' } });
+  selectOption('Status', 'not_affected');
+}
+
+function goNext() {
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+}
+
+describe('SecurityExceptionForm', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it('renders and navigates all steps', () => {
+    render(<SecurityExceptionForm />);
+    expect(screen.getByText('Scope')).toBeInTheDocument();
+    fillScope();
+    goNext();
+    enablePosture();
+    goNext();
+    fireEvent.change(screen.getByLabelText('Reason'), { target: { value: 'Accepted risk' } });
+    goNext();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+  });
+
+  it('prefills fields from props', () => {
+    render(
+      <SecurityExceptionForm
+        prefillControlID="C-0034"
+        prefillWorkloadKind="Deployment"
+        prefillWorkloadName="nginx"
+        prefillNamespace="default"
+      />
+    );
+    expect(screen.getByLabelText('Namespace')).toHaveValue('default');
+    expect(screen.getByLabelText('Workload kind')).toHaveValue('Deployment');
+    expect(screen.getByLabelText('Workload name')).toHaveValue('nginx');
+    goNext();
+    expect(screen.getByLabelText('Control ID')).toHaveValue('C-0034');
+  });
+
+  it('disables Next until scope fields are valid', () => {
+    render(<SecurityExceptionForm />);
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(next).toBeDisabled();
+    fillScope();
+    expect(next).toBeEnabled();
+  });
+
+  it('blocks submit when reason is empty', () => {
+    render(<SecurityExceptionForm />);
+    fillScope();
+    goNext();
+    enablePosture();
+    goNext();
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(next).toBeDisabled();
+  });
+
+  it('blocks submit when expiresAt is in the past', () => {
+    render(<SecurityExceptionForm />);
+    fillScope();
+    goNext();
+    enablePosture();
+    goNext();
+    fireEvent.change(screen.getByLabelText('Reason'), { target: { value: 'Accepted risk' } });
+    fireEvent.change(screen.getByLabelText('Expires at'), { target: { value: '2000-01-01' } });
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(next).toBeDisabled();
+  });
+
+  it('blocks step 2 when no exception type is selected', () => {
+    render(<SecurityExceptionForm />);
+    fillScope();
+    goNext();
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(next).toBeDisabled();
+  });
+
+  it('requires justification when status is not_affected', () => {
+    render(<SecurityExceptionForm />);
+    fillScope();
+    goNext();
+    enableVulnerability();
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(next).toBeDisabled();
+  });
+
+  it('submits a namespaced SecurityException and renders success state', async () => {
+    const created: CreatedResource = {
+      metadata: { name: 'se-test', namespace: 'default' },
+      kind: 'SecurityException',
+    };
+    postMock.mockResolvedValue(created);
+
+    render(<SecurityExceptionForm />);
+    fillScope();
+    goNext();
+    enablePosture();
+    goNext();
+    fireEvent.change(screen.getByLabelText('Reason'), { target: { value: 'Accepted risk' } });
+    goNext();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm and Create' }));
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByText('Created SecurityException: se-test')).toBeInTheDocument();
+    expect(screen.getByText('View details')).toBeInTheDocument();
+
+    const [path, manifest] = postMock.mock.calls[0] as [string, { metadata: { namespace?: string } }];
+    expect(path).toContain('/apis/kubescape.io/v1/namespaces/default/securityexceptions');
+    expect(manifest.metadata.namespace).toBe('default');
+  });
+
+  it('submits a ClusterSecurityException without namespace in metadata', async () => {
+    const created: CreatedResource = {
+      metadata: { name: 'cse-test' },
+      kind: 'ClusterSecurityException',
+    };
+    postMock.mockResolvedValue(created);
+
+    render(<SecurityExceptionForm />);
+    fireEvent.click(screen.getByLabelText('ClusterSecurityException (cluster-scoped)'));
+    fireEvent.change(screen.getByLabelText('Workload kind'), { target: { value: 'Deployment' } });
+    fireEvent.change(screen.getByLabelText('Workload name'), { target: { value: 'nginx' } });
+    goNext();
+    enablePosture();
+    goNext();
+    fireEvent.change(screen.getByLabelText('Reason'), { target: { value: 'Accepted risk' } });
+    goNext();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm and Create' }));
+
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [, manifest] = postMock.mock.calls[0] as [string, { metadata: { namespace?: string } }];
+    expect(manifest.metadata.namespace).toBeUndefined();
+  });
+});

--- a/src/exceptions/SecurityExceptionForm.test.tsx
+++ b/src/exceptions/SecurityExceptionForm.test.tsx
@@ -1,15 +1,16 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { post } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
 import { SecurityExceptionForm } from './SecurityExceptionForm';
 
-jest.mock('@kinvolk/headlamp-plugin/lib/ApiProxy', () => ({
-  post: jest.fn(),
-}));
+// stub canvas getContext (xterm may call this during transforms)
+(HTMLCanvasElement.prototype as any).getContext = () => ({ /* stub */ });
 
-jest.mock('@kinvolk/headlamp-plugin/lib/Utils', () => ({
-  getCluster: () => 'test-cluster',
-}));
+// Use vitest's vi.mock to ensure mocks are applied correctly
+declare const vi: any;
+vi.mock('@kinvolk/headlamp-plugin/lib/ApiProxy', () => ({ post: vi.fn() }));
+vi.mock('@kinvolk/headlamp-plugin/lib/Utils', () => ({ getCluster: () => 'test-cluster' }));
 
 interface CreatedResource {
   metadata: {
@@ -19,7 +20,13 @@ interface CreatedResource {
   kind: 'SecurityException' | 'ClusterSecurityException';
 }
 
-const postMock = post as jest.MockedFunction<typeof post>;
+const postMock = post as any;
+
+const theme = createTheme();
+(theme.palette as any).tables = { head: { borderColor: '#ccc' } };
+function renderWithProviders(ui: any) {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+}
 
 function fillScope() {
   fireEvent.change(screen.getByLabelText('Namespace'), { target: { value: 'default' } });
@@ -54,7 +61,7 @@ describe('SecurityExceptionForm', () => {
   });
 
   it('renders and navigates all steps', () => {
-    render(<SecurityExceptionForm />);
+    renderWithProviders(<SecurityExceptionForm />);
     expect(screen.getByText('Scope')).toBeInTheDocument();
     fillScope();
     goNext();
@@ -66,7 +73,7 @@ describe('SecurityExceptionForm', () => {
   });
 
   it('prefills fields from props', () => {
-    render(
+    renderWithProviders(
       <SecurityExceptionForm
         prefillControlID="C-0034"
         prefillWorkloadKind="Deployment"
@@ -82,7 +89,7 @@ describe('SecurityExceptionForm', () => {
   });
 
   it('disables Next until scope fields are valid', () => {
-    render(<SecurityExceptionForm />);
+    renderWithProviders(<SecurityExceptionForm />);
     const next = screen.getByRole('button', { name: 'Next' });
     expect(next).toBeDisabled();
     fillScope();
@@ -90,7 +97,7 @@ describe('SecurityExceptionForm', () => {
   });
 
   it('blocks submit when reason is empty', () => {
-    render(<SecurityExceptionForm />);
+    renderWithProviders(<SecurityExceptionForm />);
     fillScope();
     goNext();
     enablePosture();
@@ -100,7 +107,7 @@ describe('SecurityExceptionForm', () => {
   });
 
   it('blocks submit when expiresAt is in the past', () => {
-    render(<SecurityExceptionForm />);
+    renderWithProviders(<SecurityExceptionForm />);
     fillScope();
     goNext();
     enablePosture();
@@ -112,7 +119,7 @@ describe('SecurityExceptionForm', () => {
   });
 
   it('blocks step 2 when no exception type is selected', () => {
-    render(<SecurityExceptionForm />);
+    renderWithProviders(<SecurityExceptionForm />);
     fillScope();
     goNext();
     const next = screen.getByRole('button', { name: 'Next' });
@@ -120,7 +127,7 @@ describe('SecurityExceptionForm', () => {
   });
 
   it('requires justification when status is not_affected', () => {
-    render(<SecurityExceptionForm />);
+    renderWithProviders(<SecurityExceptionForm />);
     fillScope();
     goNext();
     enableVulnerability();

--- a/src/exceptions/SecurityExceptionForm.tsx
+++ b/src/exceptions/SecurityExceptionForm.tsx
@@ -24,16 +24,13 @@ import {
 } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { ErrorContainer } from '../common/ErrorContainer';
+import {
+  VulnerabilityStatus,
+  VulnerabilityJustification,
+} from '../softwarecomposition/SecurityException';
 
 type SecurityExceptionKind = 'SecurityException' | 'ClusterSecurityException';
 type PostureAction = 'ignore' | 'alert_only';
-type VulnerabilityStatus = 'not_affected' | 'fixed' | 'under_investigation';
-type VulnerabilityJustification =
-  | 'component_not_present'
-  | 'vulnerable_code_not_present'
-  | 'vulnerable_code_not_in_execute_path'
-  | 'vulnerable_code_cannot_be_controlled_by_adversary'
-  | 'inline_mitigations_already_exist';
 
 interface LabelSelector {
   matchLabels?: Record<string, string>;
@@ -115,6 +112,8 @@ interface SecurityExceptionFormProps {
   prefillWorkloadName?: string;
   prefillNamespace?: string;
   onClose?: () => void;
+  /** when provided, hide the exception-type chooser and preselect posture or vulnerability */
+  defaultType?: 'posture' | 'vulnerability';
 }
 
 interface FormErrors {
@@ -128,11 +127,7 @@ interface ValidationResult {
 
 const steps = ['Scope', 'Exception Type', 'Metadata', 'Review'];
 const postureActions: PostureAction[] = ['ignore', 'alert_only'];
-const vulnerabilityStatuses: VulnerabilityStatus[] = [
-  'not_affected',
-  'fixed',
-  'under_investigation',
-];
+const vulnerabilityStatuses: VulnerabilityStatus[] = ['not_affected', 'fixed', 'under_investigation'];
 const vulnerabilityJustifications: VulnerabilityJustification[] = [
   'component_not_present',
   'vulnerable_code_not_present',
@@ -149,6 +144,7 @@ export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps
     prefillWorkloadName,
     prefillNamespace,
     onClose,
+    defaultType,
   } = props;
 
   const [activeStep, setActiveStep] = useState<number>(0);
@@ -161,8 +157,12 @@ export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps
   const [workloadKind, setWorkloadKind] = useState<string>(prefillWorkloadKind ?? '');
   const [workloadName, setWorkloadName] = useState<string>(prefillWorkloadName ?? '');
 
-  const [includePosture, setIncludePosture] = useState<boolean>(Boolean(prefillControlID));
-  const [includeVulnerability, setIncludeVulnerability] = useState<boolean>(Boolean(prefillCVEID));
+  const [includePosture, setIncludePosture] = useState<boolean>(
+    defaultType ? defaultType === 'posture' : Boolean(prefillControlID)
+  );
+  const [includeVulnerability, setIncludeVulnerability] = useState<boolean>(
+    defaultType ? defaultType === 'vulnerability' : Boolean(prefillCVEID)
+  );
 
   const [posture, setPosture] = useState<PostureEntryForm>({
     controlID: prefillControlID ?? '',
@@ -290,14 +290,36 @@ export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps
     setIsSubmitting(true);
     try {
       const manifest = buildManifest();
-      const path = buildApiPath(kind, namespace);
-      const created = (await post(path, manifest)) as SecurityExceptionResource;
+      const created = (await postWithVersionFallback(manifest, kind, namespace)) as SecurityExceptionResource;
       setCreatedResource(created);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to create SecurityException';
       setErrorMessage(message);
     } finally {
       setIsSubmitting(false);
+    }
+  }
+
+  async function postWithVersionFallback(manifest: SecurityExceptionResource, kind: SecurityExceptionKind, ns: string) {
+    // try v1 first, then fall back to v1beta1 if 404/not found
+    const tryPost = async (version: 'v1' | 'v1beta1') => {
+      const m = { ...manifest, apiVersion: `kubescape.io/${version}` };
+      const path =
+        kind === 'SecurityException'
+          ? `/apis/kubescape.io/${version}/namespaces/${encodeURIComponent(ns)}/securityexceptions`
+          : `/apis/kubescape.io/${version}/clustersecurityexceptions`;
+      return post(path, m);
+    };
+
+    try {
+      return await tryPost('v1');
+    } catch (err: any) {
+      const message = err?.message ?? String(err);
+      const isNotFound = message.includes('404') || message.toLowerCase().includes('not found');
+      if (isNotFound) {
+        return await tryPost('v1beta1');
+      }
+      throw err;
     }
   }
 
@@ -450,7 +472,8 @@ export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps
     )}`;
   }
 
-  const canContinue = validation.valid && !isSubmitting;
+  const isComplete = Boolean(createdResource);
+  const canContinue = validation.valid && !isSubmitting && !isComplete;
   const detailUrl = createdResource ? buildDetailUrl(createdResource) : null;
 
   return (
@@ -745,7 +768,7 @@ export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps
         <Button
           variant="outlined"
           onClick={() => setActiveStep(prev => Math.max(prev - 1, 0))}
-          disabled={activeStep === 0 || isSubmitting}
+          disabled={activeStep === 0 || isSubmitting || isComplete}
         >
           Back
         </Button>

--- a/src/exceptions/SecurityExceptionForm.tsx
+++ b/src/exceptions/SecurityExceptionForm.tsx
@@ -460,7 +460,7 @@ export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps
     if (!resource.metadata.name) {
       return null;
     }
-    const cluster = getCluster();
+    const cluster = getCluster() ?? '';
     const plural =
       resource.kind === 'SecurityException' ? 'securityexceptions' : 'clustersecurityexceptions';
     const namespaceSegment =
@@ -554,21 +554,29 @@ export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps
 
       {activeStep === 1 && (
         <Stack spacing={3} className="rounded border border-slate-200 p-4">
-          <FormControlLabel
-            control={
-              <Switch checked={includePosture} onChange={event => setIncludePosture(event.target.checked)} />
-            }
-            label="Posture exception"
-          />
-          <FormControlLabel
-            control={
-              <Switch
-                checked={includeVulnerability}
-                onChange={event => setIncludeVulnerability(event.target.checked)}
+          {!defaultType ? (
+            <>
+              <FormControlLabel
+                control={
+                  <Switch checked={includePosture} onChange={event => setIncludePosture(event.target.checked)} />
+                }
+                label="Posture exception"
               />
-            }
-            label="Vulnerability exception"
-          />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={includeVulnerability}
+                    onChange={event => setIncludeVulnerability(event.target.checked)}
+                  />
+                }
+                label="Vulnerability exception"
+              />
+            </>
+          ) : (
+            <Typography variant="body2">
+              Creating {defaultType === 'posture' ? 'a posture' : 'a vulnerability'} exception.
+            </Typography>
+          )}
           {validation.errors.exceptionType && (
             <FormHelperText error>{validation.errors.exceptionType}</FormHelperText>
           )}

--- a/src/exceptions/SecurityExceptionForm.tsx
+++ b/src/exceptions/SecurityExceptionForm.tsx
@@ -1,0 +1,775 @@
+import { post } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
+import { NameValueTable } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import { getCluster } from '@kinvolk/headlamp-plugin/lib/Utils';
+import {
+  Alert,
+  Box,
+  Button,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  InputLabel,
+  Link,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useMemo, useState } from 'react';
+import { ErrorContainer } from '../common/ErrorContainer';
+
+type SecurityExceptionKind = 'SecurityException' | 'ClusterSecurityException';
+type PostureAction = 'ignore' | 'alert_only';
+type VulnerabilityStatus = 'not_affected' | 'fixed' | 'under_investigation';
+type VulnerabilityJustification =
+  | 'component_not_present'
+  | 'vulnerable_code_not_present'
+  | 'vulnerable_code_not_in_execute_path'
+  | 'vulnerable_code_cannot_be_controlled_by_adversary'
+  | 'inline_mitigations_already_exist';
+
+interface LabelSelector {
+  matchLabels?: Record<string, string>;
+  matchExpressions?: Array<{
+    key: string;
+    operator: string;
+    values?: string[];
+  }>;
+}
+
+interface ResourceMatch {
+  apiGroup?: string;
+  kind: string;
+  name?: string;
+}
+
+interface SecurityExceptionMatch {
+  namespaceSelector?: LabelSelector;
+  objectSelector?: LabelSelector;
+  resources?: ResourceMatch[];
+  images?: string[];
+}
+
+interface PostureExceptionEntry {
+  controlID: string;
+  frameworkName?: string;
+  action: PostureAction;
+}
+
+interface VulnerabilityExceptionEntry {
+  vulnerability: {
+    id: string;
+    aliases?: string[];
+  };
+  status: VulnerabilityStatus;
+  justification?: VulnerabilityJustification;
+  impactStatement?: string;
+  expiredOnFix?: boolean;
+}
+
+interface SecurityExceptionSpec {
+  author?: string;
+  reason: string;
+  expiresAt?: string;
+  match?: SecurityExceptionMatch;
+  posture?: PostureExceptionEntry[];
+  vulnerabilities?: VulnerabilityExceptionEntry[];
+}
+
+interface SecurityExceptionResource {
+  apiVersion: 'kubescape.io/v1';
+  kind: SecurityExceptionKind;
+  metadata: {
+    name?: string;
+    generateName?: string;
+    namespace?: string;
+  };
+  spec: SecurityExceptionSpec;
+}
+
+interface PostureEntryForm {
+  controlID: string;
+  frameworkName: string;
+  action: PostureAction;
+}
+
+interface VulnerabilityEntryForm {
+  cveId: string;
+  status: VulnerabilityStatus;
+  justification: VulnerabilityJustification | '';
+  impactStatement: string;
+  expiredOnFix: boolean;
+}
+
+interface SecurityExceptionFormProps {
+  prefillControlID?: string;
+  prefillCVEID?: string;
+  prefillWorkloadKind?: string;
+  prefillWorkloadName?: string;
+  prefillNamespace?: string;
+  onClose?: () => void;
+}
+
+interface FormErrors {
+  [key: string]: string;
+}
+
+interface ValidationResult {
+  valid: boolean;
+  errors: FormErrors;
+}
+
+const steps = ['Scope', 'Exception Type', 'Metadata', 'Review'];
+const postureActions: PostureAction[] = ['ignore', 'alert_only'];
+const vulnerabilityStatuses: VulnerabilityStatus[] = [
+  'not_affected',
+  'fixed',
+  'under_investigation',
+];
+const vulnerabilityJustifications: VulnerabilityJustification[] = [
+  'component_not_present',
+  'vulnerable_code_not_present',
+  'vulnerable_code_not_in_execute_path',
+  'vulnerable_code_cannot_be_controlled_by_adversary',
+  'inline_mitigations_already_exist',
+];
+
+export function SecurityExceptionForm(props: Readonly<SecurityExceptionFormProps>) {
+  const {
+    prefillControlID,
+    prefillCVEID,
+    prefillWorkloadKind,
+    prefillWorkloadName,
+    prefillNamespace,
+    onClose,
+  } = props;
+
+  const [activeStep, setActiveStep] = useState<number>(0);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [createdResource, setCreatedResource] = useState<SecurityExceptionResource | null>(null);
+
+  const [kind, setKind] = useState<SecurityExceptionKind>('SecurityException');
+  const [namespace, setNamespace] = useState<string>(prefillNamespace ?? '');
+  const [workloadKind, setWorkloadKind] = useState<string>(prefillWorkloadKind ?? '');
+  const [workloadName, setWorkloadName] = useState<string>(prefillWorkloadName ?? '');
+
+  const [includePosture, setIncludePosture] = useState<boolean>(Boolean(prefillControlID));
+  const [includeVulnerability, setIncludeVulnerability] = useState<boolean>(Boolean(prefillCVEID));
+
+  const [posture, setPosture] = useState<PostureEntryForm>({
+    controlID: prefillControlID ?? '',
+    frameworkName: '',
+    action: 'alert_only',
+  });
+
+  const [vulnerability, setVulnerability] = useState<VulnerabilityEntryForm>({
+    cveId: prefillCVEID ?? '',
+    status: 'not_affected',
+    justification: '',
+    impactStatement: '',
+    expiredOnFix: false,
+  });
+
+  const [author, setAuthor] = useState<string>('');
+  const [reason, setReason] = useState<string>('');
+  const [expiresAt, setExpiresAt] = useState<string>('');
+
+  const validation = useMemo(
+    () => validateStep(activeStep),
+    [
+      activeStep,
+      kind,
+      namespace,
+      workloadKind,
+      workloadName,
+      includePosture,
+      includeVulnerability,
+      posture,
+      vulnerability,
+      reason,
+      expiresAt,
+    ]
+  );
+
+  function validateStep(step: number): ValidationResult {
+    switch (step) {
+      case 0:
+        return validateScope();
+      case 1:
+        return validateExceptionType();
+      case 2:
+        return validateMetadata();
+      case 3:
+        return validateAll();
+      default:
+        return { valid: true, errors: {} };
+    }
+  }
+
+  function validateScope(): ValidationResult {
+    const errors: FormErrors = {};
+    if (!kind) {
+      errors.kind = 'Select a kind';
+    }
+    if (kind === 'SecurityException' && !namespace.trim()) {
+      errors.namespace = 'Namespace is required for SecurityException';
+    }
+    if (!workloadKind.trim()) {
+      errors.workloadKind = 'Workload kind is required';
+    }
+    if (!workloadName.trim()) {
+      errors.workloadName = 'Workload name is required';
+    }
+    return { valid: Object.keys(errors).length === 0, errors };
+  }
+
+  function validateExceptionType(): ValidationResult {
+    const errors: FormErrors = {};
+    if (!includePosture && !includeVulnerability) {
+      errors.exceptionType = 'Select posture, vulnerability, or both';
+    }
+    if (includePosture) {
+      if (!posture.controlID.trim()) {
+        errors.controlID = 'Control ID is required';
+      }
+      if (!postureActions.includes(posture.action)) {
+        errors.action = 'Action must be ignore or alert_only';
+      }
+    }
+    if (includeVulnerability) {
+      if (!vulnerability.cveId.trim()) {
+        errors.cveId = 'CVE ID is required';
+      }
+      if (!vulnerabilityStatuses.includes(vulnerability.status)) {
+        errors.status = 'Status must be not_affected, fixed, or under_investigation';
+      }
+      if (vulnerability.status === 'not_affected' && !vulnerability.justification) {
+        errors.justification = 'Justification is required when status is not_affected';
+      }
+    }
+    return { valid: Object.keys(errors).length === 0, errors };
+  }
+
+  function validateMetadata(): ValidationResult {
+    const errors: FormErrors = {};
+    if (!reason.trim()) {
+      errors.reason = 'Reason is required';
+    }
+    if (expiresAt && !isFutureDate(expiresAt)) {
+      errors.expiresAt = 'Expires at must be a future date';
+    }
+    return { valid: Object.keys(errors).length === 0, errors };
+  }
+
+  function validateAll(): ValidationResult {
+    const scope = validateScope();
+    const type = validateExceptionType();
+    const meta = validateMetadata();
+    return {
+      valid: scope.valid && type.valid && meta.valid,
+      errors: { ...scope.errors, ...type.errors, ...meta.errors },
+    };
+  }
+
+  async function handleSubmit() {
+    const allValidation = validateAll();
+    if (!allValidation.valid) {
+      setErrorMessage('Fix validation errors before submitting');
+      setActiveStep(firstInvalidStep(allValidation.errors));
+      return;
+    }
+    setErrorMessage('');
+    setIsSubmitting(true);
+    try {
+      const manifest = buildManifest();
+      const path = buildApiPath(kind, namespace);
+      const created = (await post(path, manifest)) as SecurityExceptionResource;
+      setCreatedResource(created);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create SecurityException';
+      setErrorMessage(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function buildManifest(): SecurityExceptionResource {
+    const match = buildMatch();
+    const spec: SecurityExceptionSpec = {
+      reason: reason.trim(),
+    };
+    if (author.trim()) {
+      spec.author = author.trim();
+    }
+    if (expiresAt) {
+      spec.expiresAt = new Date(expiresAt).toISOString();
+    }
+    if (match) {
+      spec.match = match;
+    }
+    if (includePosture) {
+      spec.posture = [
+        {
+          controlID: posture.controlID.trim(),
+          frameworkName: posture.frameworkName.trim() || undefined,
+          action: posture.action,
+        },
+      ];
+    }
+    if (includeVulnerability) {
+      spec.vulnerabilities = [
+        {
+          vulnerability: {
+            id: vulnerability.cveId.trim(),
+          },
+          status: vulnerability.status,
+          justification:
+            vulnerability.status === 'not_affected'
+              ? (vulnerability.justification as VulnerabilityJustification)
+              : undefined,
+          impactStatement: vulnerability.impactStatement.trim() || undefined,
+          expiredOnFix: vulnerability.expiredOnFix,
+        },
+      ];
+    }
+
+    const manifest: SecurityExceptionResource = {
+      apiVersion: 'kubescape.io/v1',
+      kind,
+      metadata: {
+        generateName: buildGenerateName(),
+      },
+      spec,
+    };
+
+    if (kind === 'SecurityException') {
+      manifest.metadata.namespace = namespace.trim();
+    }
+    return manifest;
+  }
+
+  function buildMatch(): SecurityExceptionMatch | undefined {
+    const match: SecurityExceptionMatch = {};
+    if (workloadKind.trim()) {
+      match.resources = [
+        {
+          kind: workloadKind.trim(),
+          name: workloadName.trim() || undefined,
+        },
+      ];
+    }
+    if (kind === 'ClusterSecurityException' && namespace.trim()) {
+      match.namespaceSelector = {
+        matchLabels: {
+          'kubernetes.io/metadata.name': namespace.trim(),
+        },
+      };
+    }
+    if (Object.keys(match).length === 0) {
+      return undefined;
+    }
+    return match;
+  }
+
+  function buildGenerateName(): string {
+    const source = [
+      includePosture ? posture.controlID : '',
+      includeVulnerability ? vulnerability.cveId : '',
+      workloadName,
+    ]
+      .filter(Boolean)
+      .join('-');
+    const prefix = sanitizeName(source).slice(0, 45) || 'securityexception';
+    return `${prefix}-`;
+  }
+
+  function buildApiPath(exceptionKind: SecurityExceptionKind, ns: string): string {
+    if (exceptionKind === 'SecurityException') {
+      return `/apis/kubescape.io/v1/namespaces/${encodeURIComponent(ns)}/securityexceptions`;
+    }
+    return '/apis/kubescape.io/v1/clustersecurityexceptions';
+  }
+
+  function firstInvalidStep(errors: FormErrors): number {
+    if (errors.kind || errors.namespace || errors.workloadKind || errors.workloadName) {
+      return 0;
+    }
+    if (
+      errors.exceptionType ||
+      errors.controlID ||
+      errors.action ||
+      errors.cveId ||
+      errors.status ||
+      errors.justification
+    ) {
+      return 1;
+    }
+    if (errors.reason || errors.expiresAt) {
+      return 2;
+    }
+    return 3;
+  }
+
+  function isFutureDate(value: string): boolean {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return false;
+    }
+    return parsed.getTime() > Date.now();
+  }
+
+  function sanitizeName(value: string): string {
+    return value
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function buildDetailUrl(resource: SecurityExceptionResource): string | null {
+    if (!resource.metadata.name) {
+      return null;
+    }
+    const cluster = getCluster();
+    const plural =
+      resource.kind === 'SecurityException' ? 'securityexceptions' : 'clustersecurityexceptions';
+    const namespaceSegment =
+      resource.kind === 'SecurityException' && resource.metadata.namespace
+        ? `/${encodeURIComponent(resource.metadata.namespace)}`
+        : '';
+    return `/c/${encodeURIComponent(cluster)}/customresources/kubescape.io/v1/${plural}${namespaceSegment}/${encodeURIComponent(
+      resource.metadata.name
+    )}`;
+  }
+
+  const canContinue = validation.valid && !isSubmitting;
+  const detailUrl = createdResource ? buildDetailUrl(createdResource) : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Stepper activeStep={activeStep}>
+        {steps.map(step => (
+          <Step key={step}>
+            <StepLabel>{step}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      {errorMessage && <ErrorContainer> {errorMessage} </ErrorContainer>}
+
+      {createdResource && (
+        <Alert severity="success" className="flex flex-col gap-2">
+          <Typography variant="body1">
+            Created {createdResource.kind}: {createdResource.metadata.name}
+          </Typography>
+          {detailUrl && <Link href={detailUrl}>View details</Link>}
+        </Alert>
+      )}
+
+      {activeStep === 0 && (
+        <Stack spacing={2} className="rounded border border-slate-200 p-4">
+          <FormControl>
+            <Typography variant="subtitle1">Kind</Typography>
+            <RadioGroup
+              row
+              value={kind}
+              onChange={event => setKind(event.target.value as SecurityExceptionKind)}
+            >
+              <FormControlLabel
+                value="SecurityException"
+                control={<Radio />}
+                label="SecurityException (namespaced)"
+              />
+              <FormControlLabel
+                value="ClusterSecurityException"
+                control={<Radio />}
+                label="ClusterSecurityException (cluster-scoped)"
+              />
+            </RadioGroup>
+            {validation.errors.kind && (
+              <FormHelperText error>{validation.errors.kind}</FormHelperText>
+            )}
+          </FormControl>
+
+          {kind === 'SecurityException' && (
+            <TextField
+              label="Namespace"
+              value={namespace}
+              onChange={event => setNamespace(event.target.value)}
+              error={Boolean(validation.errors.namespace)}
+              helperText={validation.errors.namespace}
+              fullWidth
+            />
+          )}
+
+          <TextField
+            label="Workload kind"
+            value={workloadKind}
+            onChange={event => setWorkloadKind(event.target.value)}
+            error={Boolean(validation.errors.workloadKind)}
+            helperText={validation.errors.workloadKind}
+            fullWidth
+          />
+          <TextField
+            label="Workload name"
+            value={workloadName}
+            onChange={event => setWorkloadName(event.target.value)}
+            error={Boolean(validation.errors.workloadName)}
+            helperText={validation.errors.workloadName}
+            fullWidth
+          />
+        </Stack>
+      )}
+
+      {activeStep === 1 && (
+        <Stack spacing={3} className="rounded border border-slate-200 p-4">
+          <FormControlLabel
+            control={
+              <Switch checked={includePosture} onChange={event => setIncludePosture(event.target.checked)} />
+            }
+            label="Posture exception"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={includeVulnerability}
+                onChange={event => setIncludeVulnerability(event.target.checked)}
+              />
+            }
+            label="Vulnerability exception"
+          />
+          {validation.errors.exceptionType && (
+            <FormHelperText error>{validation.errors.exceptionType}</FormHelperText>
+          )}
+
+          {includePosture && (
+            <Box className="flex flex-col gap-3">
+              <Typography variant="subtitle1">Posture</Typography>
+              <TextField
+                label="Control ID"
+                value={posture.controlID}
+                onChange={event => setPosture({ ...posture, controlID: event.target.value })}
+                error={Boolean(validation.errors.controlID)}
+                helperText={validation.errors.controlID}
+                fullWidth
+              />
+              <TextField
+                label="Framework name"
+                value={posture.frameworkName}
+                onChange={event => setPosture({ ...posture, frameworkName: event.target.value })}
+                fullWidth
+              />
+              <FormControl error={Boolean(validation.errors.action)}>
+                <InputLabel id="posture-action-label">Action</InputLabel>
+                <Select
+                  labelId="posture-action-label"
+                  label="Action"
+                  value={posture.action}
+                  onChange={event =>
+                    setPosture({ ...posture, action: event.target.value as PostureAction })
+                  }
+                >
+                  {postureActions.map(action => (
+                    <MenuItem key={action} value={action}>
+                      {action}
+                    </MenuItem>
+                  ))}
+                </Select>
+                {validation.errors.action && (
+                  <FormHelperText>{validation.errors.action}</FormHelperText>
+                )}
+              </FormControl>
+            </Box>
+          )}
+
+          {includeVulnerability && (
+            <Box className="flex flex-col gap-3">
+              <Typography variant="subtitle1">Vulnerability</Typography>
+              <TextField
+                label="CVE ID"
+                value={vulnerability.cveId}
+                onChange={event => setVulnerability({ ...vulnerability, cveId: event.target.value })}
+                error={Boolean(validation.errors.cveId)}
+                helperText={validation.errors.cveId}
+                fullWidth
+              />
+              <FormControl error={Boolean(validation.errors.status)}>
+                <InputLabel id="vuln-status-label">Status</InputLabel>
+                <Select
+                  labelId="vuln-status-label"
+                  label="Status"
+                  value={vulnerability.status}
+                  onChange={event =>
+                    setVulnerability({
+                      ...vulnerability,
+                      status: event.target.value as VulnerabilityStatus,
+                    })
+                  }
+                >
+                  {vulnerabilityStatuses.map(status => (
+                    <MenuItem key={status} value={status}>
+                      {status}
+                    </MenuItem>
+                  ))}
+                </Select>
+                {validation.errors.status && (
+                  <FormHelperText>{validation.errors.status}</FormHelperText>
+                )}
+              </FormControl>
+              {vulnerability.status === 'not_affected' && (
+                <FormControl error={Boolean(validation.errors.justification)}>
+                  <InputLabel id="vuln-justification-label">Justification</InputLabel>
+                  <Select
+                    labelId="vuln-justification-label"
+                    label="Justification"
+                    value={vulnerability.justification}
+                    onChange={event =>
+                      setVulnerability({
+                        ...vulnerability,
+                        justification: event.target.value as VulnerabilityJustification,
+                      })
+                    }
+                  >
+                    {vulnerabilityJustifications.map(justification => (
+                      <MenuItem key={justification} value={justification}>
+                        {justification}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  {validation.errors.justification && (
+                    <FormHelperText>{validation.errors.justification}</FormHelperText>
+                  )}
+                </FormControl>
+              )}
+              <TextField
+                label="Impact statement"
+                value={vulnerability.impactStatement}
+                onChange={event =>
+                  setVulnerability({ ...vulnerability, impactStatement: event.target.value })
+                }
+                fullWidth
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={vulnerability.expiredOnFix}
+                    onChange={event =>
+                      setVulnerability({ ...vulnerability, expiredOnFix: event.target.checked })
+                    }
+                  />
+                }
+                label="Expire exception when a fix is available"
+              />
+            </Box>
+          )}
+        </Stack>
+      )}
+
+      {activeStep === 2 && (
+        <Stack spacing={2} className="rounded border border-slate-200 p-4">
+          <TextField
+            label="Author"
+            value={author}
+            onChange={event => setAuthor(event.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="Reason"
+            value={reason}
+            onChange={event => setReason(event.target.value)}
+            error={Boolean(validation.errors.reason)}
+            helperText={validation.errors.reason}
+            fullWidth
+            multiline
+            minRows={3}
+          />
+          <TextField
+            label="Expires at"
+            type="date"
+            InputLabelProps={{ shrink: true }}
+            value={expiresAt}
+            onChange={event => setExpiresAt(event.target.value)}
+            error={Boolean(validation.errors.expiresAt)}
+            helperText={validation.errors.expiresAt}
+            fullWidth
+          />
+        </Stack>
+      )}
+
+      {activeStep === 3 && (
+        <Stack spacing={2} className="rounded border border-slate-200 p-4">
+          <Typography variant="subtitle1">Review</Typography>
+          <NameValueTable
+            rows={[
+              { name: 'Kind', value: kind },
+              {
+                name: 'Namespace',
+                value: kind === 'SecurityException' ? namespace : 'cluster-scoped',
+              },
+              { name: 'Workload', value: `${workloadKind}/${workloadName}` },
+              {
+                name: 'Posture',
+                value: includePosture
+                  ? `${posture.controlID}${posture.frameworkName ? ` (${posture.frameworkName})` : ''}, ${posture.action}`
+                  : 'none',
+              },
+              {
+                name: 'Vulnerability',
+                value: includeVulnerability
+                  ? `${vulnerability.cveId}, ${vulnerability.status}`
+                  : 'none',
+              },
+              { name: 'Justification', value: vulnerability.justification || 'n/a' },
+              { name: 'Impact statement', value: vulnerability.impactStatement || 'n/a' },
+              { name: 'Expired on fix', value: vulnerability.expiredOnFix ? 'true' : 'false' },
+              { name: 'Author', value: author || 'n/a' },
+              { name: 'Reason', value: reason },
+              { name: 'Expires at', value: expiresAt || 'n/a' },
+            ]}
+          />
+        </Stack>
+      )}
+
+      <Stack direction="row" spacing={2} justifyContent="flex-end">
+        <Button variant="outlined" onClick={onClose} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() => setActiveStep(prev => Math.max(prev - 1, 0))}
+          disabled={activeStep === 0 || isSubmitting}
+        >
+          Back
+        </Button>
+        {activeStep < steps.length - 1 && (
+          <Button
+            variant="contained"
+            onClick={() => {
+              if (canContinue) {
+                setActiveStep(prev => Math.min(prev + 1, steps.length - 1));
+              } else {
+                setErrorMessage('Fix validation errors before continuing');
+              }
+            }}
+            disabled={!canContinue}
+          >
+            Next
+          </Button>
+        )}
+        {activeStep === steps.length - 1 && (
+          <Button variant="contained" onClick={handleSubmit} disabled={!canContinue}>
+            Confirm and Create
+          </Button>
+        )}
+      </Stack>
+    </div>
+  );
+}

--- a/src/softwarecomposition/SecurityException.ts
+++ b/src/softwarecomposition/SecurityException.ts
@@ -1,0 +1,77 @@
+// Types for SecurityException CRD (kubescape.io/v1beta1 compatible)
+
+export interface LabelSelectorRequirement {
+  key: string;
+  operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist';
+  values?: string[];
+}
+
+export interface ResourceMatch {
+  apiGroup?: string;
+  kind: string;
+  name?: string;
+}
+
+export interface SecurityExceptionMatchSpec {
+  namespaceSelector?: {
+    matchLabels?: Record<string, string>;
+    matchExpressions?: LabelSelectorRequirement[];
+  };
+  objectSelector?: {
+    matchLabels?: Record<string, string>;
+    matchExpressions?: LabelSelectorRequirement[];
+  };
+  resources?: ResourceMatch[];
+  images?: string[];
+}
+
+export interface PostureException {
+  controlID: string;
+  frameworkName?: string;
+  action: 'ignore' | 'alert_only';
+}
+
+export type VulnerabilityStatus = 'not_affected' | 'fixed' | 'under_investigation';
+
+export type VulnerabilityJustification =
+  | 'component_not_present'
+  | 'vulnerable_code_not_present'
+  | 'vulnerable_code_cannot_be_controlled_by_adversary'
+  | 'vulnerable_code_not_in_execute_path'
+  | 'inline_mitigations_already_exist';
+
+export interface VulnerabilityRef {
+  id: string;
+  aliases?: string[];
+}
+
+export interface VulnerabilityException {
+  vulnerability: VulnerabilityRef;
+  status: VulnerabilityStatus;
+  justification?: VulnerabilityJustification;
+  impactStatement?: string;
+  expiredOnFix?: boolean;
+}
+
+export interface SecurityExceptionSpec {
+  author?: string;
+  reason?: string;
+  expiresAt?: string;
+  match?: SecurityExceptionMatchSpec;
+  posture?: PostureException[];
+  vulnerabilities?: VulnerabilityException[];
+}
+
+export interface SecurityException {
+  apiVersion: 'kubescape.io/v1beta1' | string;
+  kind: 'SecurityException';
+  metadata: { name: string; namespace: string; creationTimestamp?: string; uid?: string };
+  spec: SecurityExceptionSpec;
+}
+
+export interface ClusterSecurityException {
+  apiVersion: 'kubescape.io/v1beta1' | string;
+  kind: 'ClusterSecurityException';
+  metadata: { name: string; creationTimestamp?: string; uid?: string };
+  spec: SecurityExceptionSpec;
+}

--- a/src/vulnerabilities/WorkloadScanDetails.tsx
+++ b/src/vulnerabilities/WorkloadScanDetails.tsx
@@ -9,7 +9,8 @@ import {
   Table as HeadlampTable,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { FormControlLabel, Link, Switch } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { CreateExceptionButton } from '../exceptions/CreateExceptionButton';
 import makeSeverityLabel from '../common/SeverityLabel';
 import { getURLSegments } from '../common/url';
 import { VulnerabilityManifest } from '../softwarecomposition/VulnerabilityManifest';
@@ -76,7 +77,15 @@ export default function KubescapeVulnerabilityDetails() {
             ]}
           />
 
-          {manifestAll && <Matches manifest={manifestAll} relevant={manifestRelevant} />}
+          {manifestAll && (
+            <Matches
+              manifest={manifestAll}
+              relevant={manifestRelevant}
+              workloadKind={summary.metadata.labels['kubescape.io/workload-kind']}
+              workloadName={summary.metadata.labels['kubescape.io/workload-name']}
+              workloadNamespace={summary.metadata.labels['kubescape.io/workload-namespace']}
+            />
+          )}
         </SectionBox>
 
         {/* <SectionBox title="Summary">
@@ -91,11 +100,16 @@ export default function KubescapeVulnerabilityDetails() {
   );
 }
 
-function Matches(props: {
-  manifest: VulnerabilityManifest;
-  relevant: VulnerabilityManifest | null;
-}) {
-  const { manifest, relevant } = props;
+function Matches(
+  props: Readonly<{
+    manifest: VulnerabilityManifest;
+    relevant: VulnerabilityManifest | null;
+    workloadKind: string;
+    workloadName: string;
+    workloadNamespace: string;
+  }>
+) {
+  const { manifest, relevant, workloadKind, workloadName, workloadNamespace } = props;
   const results: VulnerabilityManifest.Match[] = manifest?.spec.payload.matches;
   const [isRelevantCVESwitchChecked, setIsRelevantCVESwitchChecked] = useState(true);
 
@@ -112,7 +126,7 @@ function Matches(props: {
         checked={isRelevantCVESwitchChecked}
         control={<Switch color="primary" />}
         label={'Relevant CVE'}
-        onChange={(event: any, checked: boolean) => {
+        onChange={(event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
           setIsRelevantCVESwitchChecked(checked);
         }}
       />
@@ -122,14 +136,21 @@ function Matches(props: {
           {
             header: 'Severity',
             accessorKey: 'vulnerability.severity',
-            Cell: ({ cell }: any) => makeSeverityLabel(cell.getValue()),
+            Cell: ({ cell }: { cell: { getValue: () => string } }) =>
+              makeSeverityLabel(cell.getValue()),
             gridTemplate: 'auto',
           },
           {
             header: 'CVE',
             accessorKey: 'vulnerability.id',
-            Cell: ({ cell }: any) => (
-              <Link target="_blank" href={cell.row.original.vulnerability.dataSource}>
+            Cell: ({
+              cell,
+              row,
+            }: {
+              cell: { getValue: () => string };
+              row: { original: VulnerabilityManifest.Match };
+            }) => (
+              <Link target="_blank" href={row.original.vulnerability.dataSource}>
                 {cell.getValue()}
               </Link>
             ),
@@ -182,7 +203,21 @@ function Matches(props: {
           {
             header: 'Description',
             accessorKey: 'vulnerability.description',
-            Cell: ({ cell }: any) => <ShowHideLabel>{cell.getValue()}</ShowHideLabel>,
+            Cell: ({ cell }: { cell: { getValue: () => string } }) => (
+              <ShowHideLabel>{cell.getValue()}</ShowHideLabel>
+            ),
+          },
+          {
+            header: 'Exception',
+            accessorFn: (match: VulnerabilityManifest.Match) => (
+              <CreateExceptionButton
+                prefillCVEID={match.vulnerability.id}
+                prefillWorkloadKind={workloadKind}
+                prefillWorkloadName={workloadName}
+                prefillNamespace={workloadNamespace}
+              />
+            ),
+            gridTemplate: 'min-content',
           },
         ]}
         initialState={{

--- a/src/vulnerabilities/WorkloadScanDetails.tsx
+++ b/src/vulnerabilities/WorkloadScanDetails.tsx
@@ -150,7 +150,11 @@ function Matches(
               cell: { getValue: () => string };
               row: { original: VulnerabilityManifest.Match };
             }) => (
-              <Link target="_blank" href={row.original.vulnerability.dataSource}>
+              <Link
+                target="_blank"
+                rel="noopener noreferrer"
+                href={row.original.vulnerability.dataSource}
+              >
                 {cell.getValue()}
               </Link>
             ),
@@ -215,6 +219,7 @@ function Matches(
                 prefillWorkloadKind={workloadKind}
                 prefillWorkloadName={workloadName}
                 prefillNamespace={workloadNamespace}
+                defaultType="vulnerability"
               />
             ),
             gridTemplate: 'min-content',

--- a/src/vulnerabilities/WorkloadScanDetails.tsx
+++ b/src/vulnerabilities/WorkloadScanDetails.tsx
@@ -9,7 +9,7 @@ import {
   Table as HeadlampTable,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import { FormControlLabel, Link, Switch } from '@mui/material';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CreateExceptionButton } from '../exceptions/CreateExceptionButton';
 import makeSeverityLabel from '../common/SeverityLabel';
 import { getURLSegments } from '../common/url';
@@ -126,7 +126,7 @@ function Matches(
         checked={isRelevantCVESwitchChecked}
         control={<Switch color="primary" />}
         label={'Relevant CVE'}
-        onChange={(event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+        onChange={(_event: any, checked: boolean) => {
           setIsRelevantCVESwitchChecked(checked);
         }}
       />


### PR DESCRIPTION
This pull request introduces a new "Create Exception" workflow for both compliance controls and vulnerability matches, making it easier for users to create security exceptions directly from scan results. It adds a reusable `CreateExceptionButton` component, integrates it into compliance and vulnerability scan details, and provides comprehensive test coverage for the exception form. Additionally, the code improves type safety in several places.

**Exception Management Integration:**

* Added a new `CreateExceptionButton` component (`src/exceptions/CreateExceptionButton.tsx`) that opens a dialog to create a security exception, prefilled with relevant workload or vulnerability information.
* Integrated the `CreateExceptionButton` into the compliance scan details table, so users can create exceptions for failed controls that are not already excepted. [[1]](diffhunk://#diff-69eee73f4e0fc2114ec8a3b0d69d26fbaaa202e308caa2b56e531c89e79ac758R14) [[2]](diffhunk://#diff-69eee73f4e0fc2114ec8a3b0d69d26fbaaa202e308caa2b56e531c89e79ac758R176-R201)
* Added the `CreateExceptionButton` to each vulnerability match row in the vulnerabilities scan details, allowing exceptions to be created for specific CVEs. [[1]](diffhunk://#diff-37d2a61a2ba5f0afd23892807e03830823b8de4de3be59e119cca4e15546c139L12-R13) [[2]](diffhunk://#diff-37d2a61a2ba5f0afd23892807e03830823b8de4de3be59e119cca4e15546c139L79-R88) [[3]](diffhunk://#diff-37d2a61a2ba5f0afd23892807e03830823b8de4de3be59e119cca4e15546c139L94-R112) [[4]](diffhunk://#diff-37d2a61a2ba5f0afd23892807e03830823b8de4de3be59e119cca4e15546c139L185-R220)

**Testing and Validation:**

* Added comprehensive tests for `SecurityExceptionForm`, covering form navigation, field validation, prefill functionality, and correct API submission for both namespaced and cluster-scoped exceptions.

**Type Safety and Code Quality:**

* Improved type annotations for table cell renderers and event handlers in `WorkloadScanDetails.tsx` and `WorkloadScanDetails.tsx` (vulnerabilities), replacing `any` with explicit types for better type safety and maintainability. [[1]](diffhunk://#diff-69eee73f4e0fc2114ec8a3b0d69d26fbaaa202e308caa2b56e531c89e79ac758L105-R113) [[2]](diffhunk://#diff-37d2a61a2ba5f0afd23892807e03830823b8de4de3be59e119cca4e15546c139L115-R129) [[3]](diffhunk://#diff-37d2a61a2ba5f0afd23892807e03830823b8de4de3be59e119cca4e15546c139L125-R153) [[4]](diffhunk://#diff-37d2a61a2ba5f0afd23892807e03830823b8de4de3be59e119cca4e15546c139L185-R220)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Exception” column with a Create Exception action for failed compliance controls in workload scans
  * Added “Exception” column and prefilled create-exception action for CVEs in vulnerability findings
  * New multi-step Security Exception form for creating posture or vulnerability exceptions (scope, type, metadata, review)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->