### PR TITLE
build(deps): bump github/codeql-action init and analyze from 4.37.0 to 4.37.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -100,6 +100,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Bumps both `github/codeql-action/init` and `github/codeql-action/analyze` from 4.37.0 to 4.37.1 in `.github/workflows/codeql.yml`, in a single commit. The two steps must run the same version or CodeQL analysis fails, so the split Dependabot PRs (#123, #125) cannot pass CI individually.

## Why combined

Dependabot split this bump into one PR per sub-action — #123 (`analyze`) and #125 (`init`) — so each PR moves only half of a pair that must stay in lockstep. CodeQL rejects a mismatched pair, and all three `Analyze` jobs fail on both PRs:

- #123: `Loaded a configuration file for version '4.37.0', but running version '4.37.1'`
- #125: `Loaded a configuration file for version '4.37.1', but running version '4.37.0'`

Both also emit: *"Not all workflow steps that use `github/codeql-action` actions use the same version."*

Merging either one alone would leave `main` red until the other rebased and merged. This PR bumps both lines at once, so CI is green at every point.

The pinned SHA `7188fc363630916deb702c7fdcf4e481b751f97a` is the commit that tag `v4.37.1` resolves to upstream, and is byte-identical to what Dependabot proposed in both PRs. It also matches the `codeql-action/upload-sarif` pin already on `main` in `scorecard.yml` (merged via #127).

## Follow-up

Close #123 and #125 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CodeQL security analysis workflow to the latest patch release.
  * Existing language, build, and analysis settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->