### PR TITLE
ci: group github/codeql-action bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      codeql-action:
+        patterns:
+          - 'github/codeql-action/*'


### PR DESCRIPTION
## Summary
- Add a Dependabot `groups` entry for `github/codeql-action/*` under the `github-actions` ecosystem so `init`, `analyze`, and `upload-sarif` bump together in a single PR instead of independent ones.

## Why
`codeql-action` requires the `init` and `analyze` steps to run the same version. Right now Dependabot opens one PR per action (#149 `analyze`, #150 `init`, #152 `upload-sarif`), which can land out of order and break CI — confirmed on #149, which fails with `Loaded a configuration file for version '4.37.6', but running version '4.37.7'` because `init` is still pinned to 4.37.6 there.

## Note
This only changes how *future* Dependabot runs group PRs — it does not retroactively merge or re-create #149/#150/#152. Those still need to be resolved by hand (see #149 for details).

## Test plan
- [ ] After merge, next Dependabot run (or a manual "Check for updates") for `github-actions` opens a single combined PR for any future `codeql-action` bump instead of one per sub-action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped GitHub CodeQL action dependency updates for more streamlined maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->